### PR TITLE
Fix SqfliteStore init bug

### DIFF
--- a/lib/sqlite_store.dart
+++ b/lib/sqlite_store.dart
@@ -13,7 +13,9 @@ class SqfliteStore {
   Future init() async {
     var dir = await getApplicationDocumentsDirectory();
     var dbPath = path.join(dir.path, 'sqlite.db');
-    await File(dbPath).delete();
+    if (await File(dbPath).exists()) {
+      await File(dbPath).delete();
+    }
     db = await openDatabase(
       dbPath,
       onCreate: (db, version) async {


### PR DESCRIPTION
Fixes this bug
```
E/flutter (14253): [ERROR:flutter/lib/ui/ui_dart_state.cc(148)] Unhandled Exception: FileSystemException: Cannot delete file, path = '/data/user/0/com.example.hive_benchmark/app_flutter/sqlite.db' (OS Error: No such file or directory, errno = 2)
E/flutter (14253): #0      _File._delete.<anonymous closure> (dart:io/file_impl.dart:291)
E/flutter (14253): #1      _rootRunUnary (dart:async/zone.dart:1132)
E/flutter (14253): #2      _CustomZone.runUnary (dart:async/zone.dart:1029)
E/flutter (14253): #3      _FutureListener.handleValue (dart:async/future_impl.dart:126)
E/flutter (14253): #4      Future._propagateToListeners.handleValueCallback (dart:async/future_impl.dart:639)
E/flutter (14253): #5      Future._propagateToListeners (dart:async/future_impl.dart:668)
E/flutter (14253): #6      Future._completeWithValue (dart:async/future_impl.dart:483)
E/flutter (14253): #7      Future._asyncComplete.<anonymous closure> (dart:async/future_impl.dart:513)
E/flutter (14253): #8      _rootRun (dart:async/zone.dart:1124)
E/flutter (14253): #9      _CustomZone.run (dart:async/zone.dart:1021)
E/flutter (14253): #10     _CustomZone.runGuarded (dart:async/zone.dart:923)
E/flutter (14253): #11     _CustomZone.bindCallbackGuarded.<anonymous closure> (dart:async/zone.dart:963)
E/flutter (14253): #12     _microtaskLoop (dart:async/schedule_microtask.dart:41)
E/flutter (14253): #13     _startMicrotaskLoop (dart:async/schedule_microtask.dart:50)
```